### PR TITLE
Add cluster name feature

### DIFF
--- a/bundle/manifests/consoledefenders.pcc.paloaltonetworks.com.crd.yaml
+++ b/bundle/manifests/consoledefenders.pcc.paloaltonetworks.com.crd.yaml
@@ -52,6 +52,8 @@ spec:
                 type: object
               defenderConfig:
                 properties:
+                  cluster:
+                    type: string
                   collectPodLabels:
                     default: false
                     type: boolean

--- a/bundle/manifests/defenders.pcc.paloaltonetworks.com.crd.yaml
+++ b/bundle/manifests/defenders.pcc.paloaltonetworks.com.crd.yaml
@@ -27,6 +27,8 @@ spec:
                 type: object
               defenderConfig:
                 properties:
+                  cluster:
+                    type: string
                   clusterAddress:
                     type: string
                   collectPodLabels:

--- a/config/crd/bases/pcc.paloaltonetworks.com_consoledefenders.yaml
+++ b/config/crd/bases/pcc.paloaltonetworks.com_consoledefenders.yaml
@@ -67,6 +67,8 @@ spec:
               defenderConfig:
                 type: object
                 properties:
+                  cluster:
+                    type: string
                   collectPodLabels:
                     type: boolean
                     default: false

--- a/config/crd/bases/pcc.paloaltonetworks.com_defenders.yaml
+++ b/config/crd/bases/pcc.paloaltonetworks.com_defenders.yaml
@@ -42,6 +42,8 @@ spec:
               defenderConfig:
                 type: object
                 properties:
+                  cluster:
+                    type: string
                   clusterAddress:
                     type: string
                   collectPodLabels:

--- a/docs/Kubernetes/resource_spec.md
+++ b/docs/Kubernetes/resource_spec.md
@@ -67,6 +67,9 @@ They are ultimately passed to `twistcli` for YAML generation.
 - **defenderConfig** (PrismaCloudComputeDefenderConfig)  
 Options for installing Defender.
 They are ultimately passed to `twistcli` for YAML generation.
+  - **defenderConfig.cluster** (string)  
+  A cluster name to identify the kubernetes cluster.
+  If no value specified, defender will try to automatically get the cluster name from the cloud provider.
   - **defenderConfig.clusterAddress** (string)  
   Host name used by Defender to verify Console certificate.
   Must be one of the SANs listed at Manage > Defenders > Names.

--- a/docs/OpenShift/resource_spec.md
+++ b/docs/OpenShift/resource_spec.md
@@ -67,6 +67,9 @@ They are ultimately passed to `twistcli` for YAML generation.
 - **defenderConfig** (PrismaCloudComputeDefenderConfig)  
 Options for installing Defender.
 They are ultimately passed to `twistcli` for YAML generation.
+  - **defenderConfig.cluster** (string)  
+  A cluster name to identify the openshift cluster.
+  If no value specified, defender will try to automatically get the cluster name from the cloud provider.
   - **defenderConfig.clusterAddress** (string)  
   Host name used by Defender to verify Console certificate.
   Must be one of the SANs listed at Manage > Defenders > Names.

--- a/roles/consoledefender/tasks/main.yml
+++ b/roles/consoledefender/tasks/main.yml
@@ -73,6 +73,7 @@
     --user {{ username }}
     --address https://twistlock-console.{{ namespace }}:8083
     --cluster-address twistlock-console
+    {{ ('--cluster ' + defenderConfig.cluster) if defenderConfig.cluster is defined else '' }}
     {{ '--collect-pod-labels' if defenderConfig.collectPodLabels else '' }}
     {{ '--cri' if not defenderConfig.docker else '' }}
     {{ ('--docker-socket-path ' + defenderConfig.dockerSocketPath) if defenderConfig.dockerSocketPath is defined else '' }}

--- a/roles/defender/tasks/main.yml
+++ b/roles/defender/tasks/main.yml
@@ -18,6 +18,7 @@
     --user {{ username }}
     --address {{ defenderConfig.consoleAddress }}
     --cluster-address {{ defenderConfig.clusterAddress }}
+    {{ ('--cluster ' + defenderConfig.cluster) if defenderConfig.cluster is defined else '' }}
     {{ '--collect-pod-labels' if defenderConfig.collectPodLabels else '' }}
     {{ '--cri' if not defenderConfig.docker else '' }}
     {{ ('--docker-socket-path ' + defenderConfig.dockerSocketPath) if defenderConfig.dockerSocketPath is defined else '' }}


### PR DESCRIPTION
## Description

Add cluster parameter to `defenderConfig` to allow specifying names from clusters where name can't be auto-discovered.

## Motivation and Context

In our case, we run EKS cluster with blocked metadata api and want to have a way to manually specify name.

## How Has This Been Tested?

Tested with the following Defender config:

```yaml
apiVersion: pcc.paloaltonetworks.com/v1alpha1
kind: Defender
metadata:
  name: pcc-defender
  namespace: twistlock
spec:
  namespace: twistlock
  orchestrator: kubernetes
  version: '21_08_525'
  defenderConfig:
    cluster: test-cluster
    clusterAddress: example.com
    consoleAddress: https://example.com
```

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
